### PR TITLE
Support running the gem with Ruby 3

### DIFF
--- a/protobuf_nested_struct.gemspec
+++ b/protobuf_nested_struct.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.add_dependency "google-protobuf"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"

--- a/spec/protobuf_nested_struct_spec.rb
+++ b/spec/protobuf_nested_struct_spec.rb
@@ -231,7 +231,7 @@ module ProtobufNestedStruct
         ]
       }
 
-      hash2 = YAML.load(YAML.dump(hash))
+      hash2 = YAML.safe_load(YAML.dump(hash), permitted_classes: [Date, Time])
       v = Value.new
       v.from_ruby(hash)
       expect(v.to_ruby).to eql(hash2)


### PR DESCRIPTION
I noticed that with Ruby 3.x, the tests don't run and setting up is somewhat problematic.

* The gemspec required `bundler 1.x` while bundler 2.x would work just as fine
* The tests for "serializes anything" no longer work with Ruby 3.1 and Psych 4 (https://www.ctrl.blog/entry/ruby-psych4.html)

With these changes `bundle exec rspec` is passing for me locally.